### PR TITLE
Activate queryable state runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,9 @@ RUN set -ex; \
   rm flink.tgz; \
   \
   chown -R flink:flink .;
+  
+# Activate queryable state runtime
+RUN cp /opt/flink/opt/flink-queryable-state-runtime_2.12-1.10.1.jar /opt/flink/lib
 
 COPY docker-entrypoint.sh /
 


### PR DESCRIPTION
To enable queryable state on your Flink cluster, you need to do the following:

copy the flink-queryable-state-runtime_2.11-1.10.0.jar from the opt/ folder of your Flink distribution, to the lib/ folder.